### PR TITLE
chore: add CI workflow for lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: textlint
+        run: bunx --bun textlint README.md
+
+      - name: cspell
+        run: bunx --bun cspell README.md
+
+      - name: markdownlint
+        run: bunx --bun markdownlint-cli2 README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,12 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: textlint
-        run: bunx --bun textlint README.md
-
-      - name: cspell
-        run: bunx --bun cspell README.md
-
-      - name: markdownlint
-        run: bunx --bun markdownlint-cli2 README.md
+      - name: Lint
+        run: task ci

--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -8,7 +8,8 @@ rules:
     no-doubled-joshi: false
     sentence-length:
       max: 1000
-  preset-ja-spacing: true
+  preset-ja-spacing:
+    ja-no-space-around-slash: false
   aws-service-name: true
   ja-hiragana-daimeishi: true
   ja-hiragana-fukushi: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,15 +23,15 @@ tasks:
 
   textlint:
     desc: "Run textlint"
-    cmd: bunx --bun textlint README.md {{.CLI_ARGS}}
+    cmd: bunx textlint README.md {{.CLI_ARGS}}
 
   cspell:
     desc: "Run cspell"
-    cmd: bunx --bun cspell README.md {{.CLI_ARGS}}
+    cmd: bunx cspell README.md {{.CLI_ARGS}}
 
   markdownlint:
     desc: "Run markdownlint"
-    cmd: bunx --bun markdownlint-cli2 README.md {{.CLI_ARGS}}
+    cmd: bunx markdownlint-cli2 README.md {{.CLI_ARGS}}
 
   generate-pdf:
     desc: "Generate PDF"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,17 +14,24 @@ tasks:
       - task cspell || true
       - task markdownlint || true
 
+  ci:
+    desc: "Run CI checks"
+    cmds:
+      - task textlint
+      - task cspell
+      - task markdownlint
+
   textlint:
     desc: "Run textlint"
-    cmd: bunx textlint README.md {{.CLI_ARGS}}
+    cmd: bunx --bun textlint README.md {{.CLI_ARGS}}
 
   cspell:
     desc: "Run cspell"
-    cmd: bunx cspell README.md {{.CLI_ARGS}}
+    cmd: bunx --bun cspell README.md {{.CLI_ARGS}}
 
   markdownlint:
     desc: "Run markdownlint"
-    cmd: bunx markdownlint-cli2 README.md {{.CLI_ARGS}}
+    cmd: bunx --bun markdownlint-cli2 README.md {{.CLI_ARGS}}
 
   generate-pdf:
     desc: "Generate PDF"

--- a/bun.lock
+++ b/bun.lock
@@ -4,23 +4,23 @@
   "workspaces": {
     "": {
       "devDependencies": {
-        "cspell": "latest",
-        "markdownlint-cli2": "latest",
-        "md-to-pdf": "latest",
-        "puppeteer": "latest",
-        "puppeteer-core": "latest",
-        "textlint": "latest",
-        "textlint-filter-rule-allowlist": "latest",
-        "textlint-filter-rule-comments": "latest",
-        "textlint-rule-aws-service-name": "latest",
-        "textlint-rule-ja-hiragana-daimeishi": "latest",
-        "textlint-rule-ja-hiragana-fukushi": "latest",
-        "textlint-rule-ja-hiragana-hojodoushi": "latest",
-        "textlint-rule-ja-keishikimeishi": "latest",
-        "textlint-rule-ja-no-abusage": "latest",
-        "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "latest",
-        "textlint-rule-preset-ja-spacing": "latest",
-        "textlint-rule-preset-ja-technical-writing": "latest",
+        "cspell": "10.0.1",
+        "markdownlint-cli2": "0.23.0",
+        "md-to-pdf": "5.2.5",
+        "puppeteer": "25.3.0",
+        "puppeteer-core": "25.3.0",
+        "textlint": "15.7.1",
+        "textlint-filter-rule-allowlist": "4.0.0",
+        "textlint-filter-rule-comments": "1.3.0",
+        "textlint-rule-aws-service-name": "1.14.0",
+        "textlint-rule-ja-hiragana-daimeishi": "1.0.0",
+        "textlint-rule-ja-hiragana-fukushi": "1.3.0",
+        "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
+        "textlint-rule-ja-keishikimeishi": "1.0.5",
+        "textlint-rule-ja-no-abusage": "3.0.0",
+        "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
+        "textlint-rule-preset-ja-spacing": "3.0.2",
+        "textlint-rule-preset-ja-technical-writing": "12.0.2",
       },
     },
   },
@@ -1129,7 +1129,7 @@
 
     "longest-streak": ["longest-streak@2.0.4", "", {}, "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="],
 
-    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
@@ -2011,13 +2011,13 @@
 
     "morpheme-match-textlint/morpheme-match-all": ["morpheme-match-all@2.0.5", "", { "dependencies": { "morpheme-match": "^2.0.4" } }, "sha512-a6B6Nh4AhjMoEzVz8NOT5M9f3XwFVPM395gqnFNUXG/KTqQFTb9qM5JJFHJe+SvWfRVXTZSejyXNt+h+jmHUuQ=="],
 
+    "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
     "pkg-dir/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
     "prh/diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
 
     "prh/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
-
-    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "qified/hookified": ["hookified@2.2.0", "", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Closes #1
- Add GitHub Actions CI that runs lint via `task ci` (textlint / cspell / markdownlint)
- Install Task with `arduino/setup-task` so CI uses the same Taskfile targets as local
- Disable `ja-no-space-around-slash` so intentional resume slash spacing remains valid
- Sync `bun.lock` with the pinned versions in `package.json`

## Review follow-ups
- Use Task GitHub Action + `task ci` instead of calling `bunx` directly in the workflow
- Remove `--bun` from Taskfile commands (it was only a local Node version workaround)

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bunx textlint README.md`
- [x] `bunx markdownlint-cli2 README.md`
- [ ] Confirm the CI workflow passes on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42c8288c-4915-4208-8635-1d16f70f3e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42c8288c-4915-4208-8635-1d16f70f3e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

